### PR TITLE
Fix server.js, login.py

### DIFF
--- a/login/login.py
+++ b/login/login.py
@@ -213,4 +213,4 @@ class LoginManager:
 
 if __name__ == "__main__":
     login_manager = LoginManager()
-    LoginManager.main()
+    login_manager.main()

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "express": "latest",
     "ws": "latest",
     "node-pty": "latest",
-    "pm2": "latest"
+    "pm2": "latest",
+    "js-yaml": "^4.1.0"
   },
   "scripts": {
     "postinstall": "cd ./public && npm install"

--- a/server/server.js
+++ b/server/server.js
@@ -4,9 +4,10 @@ const http = require("http");
 const https = require("https");
 const ws = require("ws");
 const pty = require("node-pty");
+const yaml = require("js-yaml");
 
 const indexPage = fs.readFileSync("server/index.html");
-const serverConfig = JSON.parse(fs.readFileSync("config.json"));
+const serverConfig = yaml.load(fs.readFileSync("config.yaml", "utf8"));
 
 const app = express();
 var server;


### PR DESCRIPTION
Fixes `server/server.js` looking for `config.json` rather than `config.yaml`
Fixes `login/login.py` not referencing new `login_manager` instance which fixes python error when connecting
Added `js-yaml` dependency for `server.js` fix